### PR TITLE
Make resizing action correct 

### DIFF
--- a/src/microui.c
+++ b/src/microui.c
@@ -1117,11 +1117,22 @@ int mu_begin_window_ex(mu_Context *ctx, mu_Container *cnt, const char *title,
     mu_Rect r = mu_rect(rect.x + rect.w - sz, rect.y + rect.h - sz, sz, sz);
     mu_update_control(ctx, id, r, opt);
     mu_draw_icon(ctx, MU_ICON_RESIZE, r, ctx->style->colors[MU_COLOR_TEXT]);
+    static int resizing_id;
     if (id == ctx->focus && ctx->mouse_down == MU_MOUSE_LEFT) {
-      cnt->rect.w += ctx->mouse_delta.x;
-      cnt->rect.h += ctx->mouse_delta.y;
+      static mu_Vec2 cursor_pos;
+      /* if now is the first frame during resizing */
+      if (resizing_id != id) {
+        resizing_id = id;
+        cursor_pos = mu_vec2(ctx->mouse_pos.x - r.x, ctx->mouse_pos.y - r.y);
+      }
+      cnt->rect.w = ctx->mouse_pos.x - rect.x + sz - cursor_pos.x;
+      cnt->rect.h = ctx->mouse_pos.y - rect.y + sz - cursor_pos.y;
       cnt->rect.w = mu_max(96, cnt->rect.w);
       cnt->rect.h = mu_max(64, cnt->rect.h);
+    }
+    /* if `resizing_id` WAS focused but NOW not */
+    else if (resizing_id == id) {
+      resizing_id = -1;
     }
     body.h -= sz;
   }

--- a/src/microui.h
+++ b/src/microui.h
@@ -29,6 +29,10 @@
 #define mu_max(a, b)            ((a) > (b) ? (a) : (b))
 #define mu_clamp(x, a, b)       mu_min(b, mu_max(a, x))
 
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
 enum {
   MU_CLIP_NONE,
   MU_CLIP_PART,
@@ -286,5 +290,9 @@ void mu_end_popup(mu_Context *ctx);
 void mu_begin_panel_ex(mu_Context *ctx, mu_Container *cnt, int opt);
 void mu_begin_panel(mu_Context *ctx, mu_Container *cnt);
 void mu_end_panel(mu_Context *ctx);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
 
 #endif

--- a/src/microui.h
+++ b/src/microui.h
@@ -29,10 +29,6 @@
 #define mu_max(a, b)            ((a) > (b) ? (a) : (b))
 #define mu_clamp(x, a, b)       mu_min(b, mu_max(a, x))
 
-#ifdef __cplusplus
-extern "C" {
-#endif // __cplusplus
-
 enum {
   MU_CLIP_NONE,
   MU_CLIP_PART,
@@ -290,9 +286,5 @@ void mu_end_popup(mu_Context *ctx);
 void mu_begin_panel_ex(mu_Context *ctx, mu_Container *cnt, int opt);
 void mu_begin_panel(mu_Context *ctx, mu_Container *cnt);
 void mu_end_panel(mu_Context *ctx);
-
-#ifdef __cplusplus
-} // extern "C"
-#endif // __cplusplus
 
 #endif


### PR DESCRIPTION
Let me explain the point. The resize opertion in demo is like that:
![gif0](https://user-images.githubusercontent.com/31474766/52518034-824c0680-2c7f-11e9-98e8-936fb1181d0a.gif)
If the cursor's position may make the window's size is too small, the size won't shrink more. That's all right. But when the cursor move backward the window's size enlarge directly rather than keep its size until the cursor move out of the origin press position, which windows in other GUI platforms perform.
![gif1](https://user-images.githubusercontent.com/31474766/52518220-2f278300-2c82-11e9-9c6e-552dc28814ef.gif)
I revise some code and this is the effect:
![gif2](https://user-images.githubusercontent.com/31474766/52518286-592d7500-2c83-11e9-863a-de29f4d19d95.gif)
the modifications does not destroy the library's lightweight and  fixed-sized memory region.