### PR TITLE
fix problems of resizing

### DIFF
--- a/src/microui.h
+++ b/src/microui.h
@@ -210,6 +210,9 @@ struct mu_Context {
   int key_down;
   int key_pressed;
   char input_text[32];
+  /* resize state */
+  mu_Id resizing_id;
+  mu_Vec2 resize_cursor_pos;
 };
 
 


### PR DESCRIPTION
Let me explain the point. The resize opertion in demo is like that currently:
![gif0](https://user-images.githubusercontent.com/31474766/52518034-824c0680-2c7f-11e9-98e8-936fb1181d0a.gif)
If the cursor's position may make the window's size too small, its size won't shrink more. That's all right. But  the window's size enlarge as soon as the cursor move backward rather than keep its size until the cursor move out of the original press position, which windows in other GUI platforms perform.
![gif1](https://user-images.githubusercontent.com/31474766/52518220-2f278300-2c82-11e9-9c6e-552dc28814ef.gif)
I revise some code and this is the effect:
![gif2](https://user-images.githubusercontent.com/31474766/52518286-592d7500-2c83-11e9-863a-de29f4d19d95.gif)
I add two members into mu_Context so that more than one mu_Context could work on the same process. the modifications does not destroy the library's lightweight and  fixed-sized memory region.