### PR TITLE
Add top and bottom alignment for tall rects

### DIFF
--- a/src/microui.c
+++ b/src/microui.c
@@ -634,6 +634,12 @@ void mu_draw_control_text(mu_Context *ctx, const char *str, mu_Rect rect,
   } else {
     pos.x = rect.x + ctx->style->padding;
   }
+  if (opt & MU_OPT_ALIGNTOP) {
+    pos.y = rect.y + ctx->style->padding;
+  }
+  if (opt & MU_OPT_ALIGNBOTTOM) {
+    pos.y = rect.y + rect.h - ctx->text_height(font) - ctx->style->padding;
+  }
   mu_draw_text(ctx, font, str, -1, pos, ctx->style->colors[colorid]);
   mu_pop_clip_rect(ctx);
 }

--- a/src/microui.h
+++ b/src/microui.h
@@ -88,7 +88,9 @@ enum {
   MU_OPT_HOLDFOCUS    = (1 << 8),
   MU_OPT_AUTOSIZE     = (1 << 9),
   MU_OPT_POPUP        = (1 << 10),
-  MU_OPT_CLOSED       = (1 << 11)
+  MU_OPT_CLOSED       = (1 << 11),
+  MU_OPT_ALIGNTOP     = (1 << 12),
+  MU_OPT_ALIGNBOTTOM  = (1 << 13)
 };
 
 enum {


### PR DESCRIPTION
Not sure if this is functionality that is desired, or if I'm adding to the enums in the right way, but here's the patch. Happy to update it if required!