### PR TITLE
Allow to choose popup position

### DIFF
--- a/demo/Makefile
+++ b/demo/Makefile
@@ -1,0 +1,20 @@
+UNAME_S = $(shell uname -s)
+
+CFLAGS += -Wall -pedantic -std=c11
+LDFLAGS = -lSDL2 -lm
+
+ifeq ("$(UNAME_S)", "Darwin")
+	LDFLAGS += -framework OpenGL -framework Cocoa
+else
+	LDFLAGS += -lGL
+endif
+
+demo:
+	$(CC) -o demo main.c renderer.c ../src/microui.c -I../src $(CFLAGS) $(LDFLAGS)
+
+.DEFAULT_GOAL := demo
+
+.PHONY: clean demo
+clean:
+	rm -f demo
+

--- a/demo/build.sh
+++ b/demo/build.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-gcc main.c renderer.c ../src/microui.c -I../src\
-    -Wall -std=c11 -pedantic -lSDL2 -lGL -lm -O3 -g

--- a/demo/main.c
+++ b/demo/main.c
@@ -18,6 +18,7 @@ static void write_log(const char *text) {
 
 static void test_window(mu_Context *ctx) {
   static mu_Container window;
+  static mu_Container popup;
 
   /* init window manually so we can set its position and size */
   if (!window.inited) {
@@ -100,6 +101,19 @@ static void test_window(mu_Context *ctx) {
       mu_layout_end_column(ctx);
     }
 
+    /* popups */
+    static int show_popups = 0;
+    if (mu_header(ctx, &show_popups, "Popups")) {
+      mu_layout_row(ctx, 2, (int[]) { 86, -1 }, 0);
+      mu_label(ctx, "Position");
+      mu_layout_begin_column(ctx);
+      mu_layout_row(ctx, 3, (int[]) { 60, 60, -1 }, 0);
+      if (mu_button(ctx, "Mouse")) { mu_open_popup(ctx, &popup); }
+      if (mu_button(ctx, "Fixed")) { mu_open_popup_ex(ctx, &popup, mu_vec2(10, 10)); }
+      if (mu_button(ctx, "Right")) { mu_open_popup_ex(ctx, &popup, mu_vec2(ctx->last_rect.x + ctx->last_rect.w, ctx->last_rect.y)); }
+      mu_layout_end_column(ctx);
+    }
+
     /* background color sliders */
     static int show_sliders = 1;
     if (mu_header(ctx, &show_sliders, "Background Color")) {
@@ -120,6 +134,13 @@ static void test_window(mu_Context *ctx) {
     }
 
     mu_end_window(ctx);
+  }
+
+  if (mu_begin_popup(ctx, &popup)) {
+    mu_layout_row(ctx, 1, (int[]) { 150 }, 0);
+    mu_label(ctx, "I am popup");
+    if (mu_button(ctx, "Close")) { popup.open = 0; }
+    mu_end_popup(ctx);
   }
 }
 

--- a/src/microui.c
+++ b/src/microui.c
@@ -1153,15 +1153,20 @@ void mu_end_window(mu_Context *ctx) {
 }
 
 
-void mu_open_popup(mu_Context *ctx, mu_Container *cnt) {
+void mu_open_popup_ex(mu_Context *ctx, mu_Container *cnt, mu_Vec2 pos) {
   /* set as hover root so popup isn't closed in begin_window_ex()  */
   ctx->last_hover_root = ctx->hover_root = cnt;
   /* init container if not inited */
   if (!cnt->inited) { mu_init_window(ctx, cnt, 0); }
-  /* position at mouse cursor, open and bring-to-front */
-  cnt->rect = mu_rect(ctx->mouse_pos.x, ctx->mouse_pos.y, 0, 0);
+  /* set position, open and bring-to-front */
+  cnt->rect = mu_rect(pos.x, pos.y, 0, 0);
   cnt->open = 1;
   mu_bring_to_front(ctx, cnt);
+}
+
+
+void mu_open_popup(mu_Context *ctx, mu_Container *cnt) {
+  mu_open_popup_ex(ctx, cnt, ctx->mouse_pos);
 }
 
 

--- a/src/microui.h
+++ b/src/microui.h
@@ -278,6 +278,7 @@ void mu_end_treenode(mu_Context *ctx);
 int mu_begin_window_ex(mu_Context *ctx, mu_Container *cnt, const char *title, int opt);
 int mu_begin_window(mu_Context *ctx, mu_Container *cnt, const char *title);
 void mu_end_window(mu_Context *ctx);
+void mu_open_popup_ex(mu_Context *ctx, mu_Container *cnt, mu_Vec2 pos);
 void mu_open_popup(mu_Context *ctx, mu_Container *cnt);
 int mu_begin_popup(mu_Context *ctx, mu_Container *cnt);
 void mu_end_popup(mu_Context *ctx);


### PR DESCRIPTION
Allows to choose where will the popup appear - the position. That enable us to create widgets like window menu bar or context menu with sub menu items or notification popups where you want to have full control where in the main window will the popup appear. PR also updates demo application how to use popup widget.

The Makefile/shell script change allows to compile and run demo application on MacOS.