### PR TITLE
Fix windows (Msys2/mingw64) demo build

### DIFF
--- a/demo/build.sh
+++ b/demo/build.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+if test `uname -o` == "Msys"; then
+    GL="opengl32"
+else
+    GL="GL"
+fi
 gcc main.c renderer.c ../src/microui.c -I../src\
-    -Wall -std=c11 -pedantic -lSDL2 -lGL -lm -O3 -g
+    -Wall -std=c11 -pedantic `sdl2-config --libs` -l${GL} -lm -O3 -g
 


### PR DESCRIPTION
trivial fix to let build the demo on Windows (Msys2/mingw64),
while keeping the unix-like way