### PR TITLE
align commands in the command buffer on 4 bytes

### DIFF
--- a/src/microui.c
+++ b/src/microui.c
@@ -425,6 +425,7 @@ void mu_input_text(mu_Context *ctx, const char *text) {
 **============================================================================*/
 
 mu_Command* mu_push_command(mu_Context *ctx, int type, int size) {
+  size = ((size + 3) & ~3);
   mu_Command *cmd = (mu_Command*) (ctx->command_list.items + ctx->command_list.idx);
   expect(ctx->command_list.idx + size < MU_COMMANDLIST_SIZE);
   cmd->base.type = type;


### PR DESCRIPTION
This fixes a crash when microui is used on my 32-bit ARM tablet.
The crash happens when assigning a structure variable directly to a field of an unaligned command union in the command stack.

More specifically, my situation was that I was trying to display a window with a label inside. the window alone would show just fine, but as soon as I added the label inside it, the program crashed.

I managed to narrow down the crash to line 500 of `microui.c` which happened while adding the label:
```
cmd->text.pos = pos;
```

`cmd->text.pos` was not aligned because the space occupied by the previous text command (for the window title) was not a multiple of 4 because of the length of the text.

With this patch, all commands will occupy a space that has a size which is a multiple of 4, which prevents alignment problems.
