### PR TITLE
Added a flag to prevent window dragging

### DIFF
--- a/src/microui.c
+++ b/src/microui.c
@@ -1107,7 +1107,7 @@ int mu_begin_window_ex(mu_Context *ctx, const char *title, mu_Rect rect, int opt
       mu_Id id = mu_get_id(ctx, "!title", 6);
       mu_update_control(ctx, id, tr, opt);
       mu_draw_control_text(ctx, title, tr, MU_COLOR_TITLETEXT, opt);
-      if (id == ctx->focus && ctx->mouse_down == MU_MOUSE_LEFT) {
+      if (id == ctx->focus && ctx->mouse_down == MU_MOUSE_LEFT && ~opt & MU_OPT_NODRAG) {
         cnt->rect.x += ctx->mouse_delta.x;
         cnt->rect.y += ctx->mouse_delta.y;
       }

--- a/src/microui.h
+++ b/src/microui.h
@@ -88,7 +88,8 @@ enum {
   MU_OPT_AUTOSIZE     = (1 << 9),
   MU_OPT_POPUP        = (1 << 10),
   MU_OPT_CLOSED       = (1 << 11),
-  MU_OPT_EXPANDED     = (1 << 12)
+  MU_OPT_EXPANDED     = (1 << 12),
+  MU_OPT_NODRAG       = (1 << 13)
 };
 
 enum {


### PR DESCRIPTION
Windows are missing a flag to prevent them from being dragged.
They already have one to prevent resizing, dragging is done in the same fashion.

A nice usecase I can think of is to have one microui window as the root, displayed in a borderless SDL window for example.
So the microui window doesn't have any background decoration and seems *native*.