### PR TITLE
Fix msvc warnings

### DIFF
--- a/src/microui.c
+++ b/src/microui.c
@@ -329,7 +329,7 @@ static mu_Container* get_container(mu_Context *ctx, mu_Id id, int opt) {
 
 
 mu_Container* mu_get_container(mu_Context *ctx, const char *name) {
-  mu_Id id = mu_get_id(ctx, name, strlen(name));
+  mu_Id id = mu_get_id(ctx, name, (int) strlen(name));
   return get_container(ctx, id, 0);
 }
 
@@ -413,8 +413,8 @@ void mu_input_keyup(mu_Context *ctx, int key) {
 
 
 void mu_input_text(mu_Context *ctx, const char *text) {
-  int len = strlen(ctx->input_text);
-  int size = strlen(text) + 1;
+  int len = (int) strlen(ctx->input_text);
+  int size = (int) (strlen(text) + 1);
   expect(len + size <= (int) sizeof(ctx->input_text));
   memcpy(ctx->input_text + len, text, size);
 }
@@ -492,7 +492,7 @@ void mu_draw_text(mu_Context *ctx, mu_Font font, const char *str, int len,
   if (clipped == MU_CLIP_ALL ) { return; }
   if (clipped == MU_CLIP_PART) { mu_set_clip(ctx, mu_get_clip_rect(ctx)); }
   /* add command */
-  if (len < 0) { len = strlen(str); }
+  if (len < 0) { len = (int) strlen(str); }
   cmd = mu_push_command(ctx, MU_COMMAND_TEXT, sizeof(mu_TextCommand) + len);
   memcpy(cmd->text.str, str, len);
   cmd->text.str[len] = '\0';
@@ -712,12 +712,12 @@ void mu_text(mu_Context *ctx, const char *text) {
     do {
       const char* word = p;
       while (*p && *p != ' ' && *p != '\n') { p++; }
-      w += ctx->text_width(font, word, p - word);
+      w += ctx->text_width(font, word, (int) (p - word));
       if (w > r.w && end != start) { break; }
       w += ctx->text_width(font, p, 1);
       end = p++;
     } while (*end && *end != '\n');
-    mu_draw_text(ctx, font, start, end - start, mu_vec2(r.x, r.y), color);
+    mu_draw_text(ctx, font, start, (int) (end - start), mu_vec2(r.x, r.y), color);
     p = end + 1;
   } while (*end);
   mu_layout_end_column(ctx);
@@ -731,7 +731,7 @@ void mu_label(mu_Context *ctx, const char *text) {
 
 int mu_button_ex(mu_Context *ctx, const char *label, int icon, int opt) {
   int res = 0;
-  mu_Id id = label ? mu_get_id(ctx, label, strlen(label))
+  mu_Id id = label ? mu_get_id(ctx, label, (int) strlen(label))
                    : mu_get_id(ctx, &icon, sizeof(icon));
   mu_Rect r = mu_layout_next(ctx);
   mu_update_control(ctx, id, r, opt);
@@ -777,7 +777,7 @@ int mu_textbox_raw(mu_Context *ctx, char *buf, int bufsz, mu_Id id, mu_Rect r,
 
   if (ctx->focus == id) {
     /* handle text input */
-    int len = strlen(buf);
+    int len = (int) strlen(buf);
     int n = mu_min(bufsz - len - 1, (int) strlen(ctx->input_text));
     if (n > 0) {
       memcpy(buf + len, ctx->input_text, n);
@@ -832,7 +832,7 @@ static int number_textbox(mu_Context *ctx, mu_Real *value, mu_Rect r, mu_Id id) 
     int res = mu_textbox_raw(
       ctx, ctx->number_edit_buf, sizeof(ctx->number_edit_buf), id, r, 0);
     if (res & MU_RES_SUBMIT || ctx->focus != id) {
-      *value = strtod(ctx->number_edit_buf, NULL);
+      *value = (mu_Real) strtod(ctx->number_edit_buf, NULL);
       ctx->number_edit = 0;
     } else {
       return 1;
@@ -880,7 +880,7 @@ int mu_slider_ex(mu_Context *ctx, mu_Real *value, mu_Real low, mu_Real high,
   mu_draw_control_frame(ctx, id, base, MU_COLOR_BASE, opt);
   /* draw thumb */
   w = ctx->style->thumb_size;
-  x = (v - low) * (base.w - w) / (high - low);
+  x = (int) ((v - low) * (base.w - w) / (high - low));
   thumb = mu_rect(base.x + x, base.y, w, base.h);
   mu_draw_control_frame(ctx, id, thumb, MU_COLOR_BUTTON, opt);
   /* draw text  */
@@ -926,7 +926,7 @@ int mu_number_ex(mu_Context *ctx, mu_Real *value, mu_Real step,
 static int header(mu_Context *ctx, const char *label, int istreenode, int opt) {
   mu_Rect r;
   int active, expanded;
-  mu_Id id = mu_get_id(ctx, label, strlen(label));
+  mu_Id id = mu_get_id(ctx, label, (int) strlen(label));
   int idx = mu_pool_get(ctx, ctx->treenode_pool, MU_TREENODEPOOL_SIZE, id);
   int width = -1;
   mu_layout_row(ctx, 1, &width, 0);
@@ -1082,7 +1082,7 @@ static void end_root_container(mu_Context *ctx) {
 
 int mu_begin_window_ex(mu_Context *ctx, const char *title, mu_Rect rect, int opt) {
   mu_Rect body;
-  mu_Id id = mu_get_id(ctx, title, strlen(title));
+  mu_Id id = mu_get_id(ctx, title, (int) strlen(title));
   mu_Container *cnt = get_container(ctx, id, opt);
   if (!cnt || !cnt->open) { return 0; }
   push(ctx->id_stack, id);
@@ -1190,7 +1190,7 @@ void mu_end_popup(mu_Context *ctx) {
 
 void mu_begin_panel_ex(mu_Context *ctx, const char *name, int opt) {
   mu_Container *cnt;
-  mu_push_id(ctx, name, strlen(name));
+  mu_push_id(ctx, name, (int) strlen(name));
   cnt = get_container(ctx, ctx->last_id, opt);
   cnt->rect = mu_layout_next(ctx);
   if (~opt & MU_OPT_NOFRAME) {


### PR DESCRIPTION
The Microsoft C compiler at warning level 3 (`/W3`) complains about various integer casts. I assume microui doesn't intend to handle the cases where these casts would overflow. I think it's worth making the casts explicit, to express that this is the intended behavior.