### PR TITLE
Fix mu_slider_ex step

### DIFF
--- a/src/microui.c
+++ b/src/microui.c
@@ -870,7 +870,7 @@ int mu_slider_ex(mu_Context *ctx, mu_Real *value, mu_Real low, mu_Real high,
       (ctx->mouse_down | ctx->mouse_pressed) == MU_MOUSE_LEFT)
   {
     v = low + (ctx->mouse_pos.x - base.x) * (high - low) / base.w;
-    if (step) { v = (((v + step / 2) / step)) * step; }
+    if (step) v = (int)(v / step + (v < 0 ? -0.5 : 0.5)) * step;
   }
   /* clamp and store value, update res */
   *value = v = mu_clamp(v, low, high);


### PR DESCRIPTION
Currently, the `step` parameter seems to only give an offset to the mouse position (equivalently to `v += step/2`), where you would expect it to make the slider snap to the closest value of the specified step size.

This patch achieves the desired behavior :)