### PR TITLE
Revert "Bump copyright year"

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2024 rxi
+Copyright (c) 2020 rxi
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/src/microui.c
+++ b/src/microui.c
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2024 rxi
+** Copyright (c) 2020 rxi
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and associated documentation files (the "Software"), to

--- a/src/microui.h
+++ b/src/microui.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2024 rxi
+** Copyright (c) 2020 rxi
 **
 ** This library is free software; you can redistribute it and/or modify it
 ** under the terms of the MIT license. See `microui.c` for details.


### PR DESCRIPTION
This reverts commit 20270fe9a3f90f2937fd635a68afe5220a7b8bca.

This is not how copyright years work. The year is the year authorship rights _started_. If you say “copyright 2024”, it means that you did not have authorship rights over this work in 2023.

PS. Love your work.