### PR TITLE
Fixed incorrect function name in docs

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -15,7 +15,7 @@ main loop:
   call `mu_begin()`
   process ui
   call `mu_end()`
-  iterate commands using `mu_command_next()`
+  iterate commands using `mu_next_command()`
 ```
 
 ## Getting Started


### PR DESCRIPTION
`mu_command_next` -> `mu_next_command`

[Source](https://github.com/rxi/microui/blob/0850aba860959c3e75fb3e97120ca92957f9d057/src/microui.h#L248):

```cpp
int mu_next_command(mu_Context *ctx, mu_Command **cmd);
```