### PR TITLE
Draw image extension

### DIFF
--- a/src/microui.c
+++ b/src/microui.c
@@ -473,6 +473,16 @@ void mu_draw_rect(mu_Context *ctx, mu_Rect rect, mu_Color color) {
   }
 }
 
+void mu_draw_image(mu_Context *ctx, mu_Rect rect, void* framebuffer) {
+  mu_Command *cmd;
+  rect = intersect_rects(rect, mu_get_clip_rect(ctx));
+  if (rect.w > 0 && rect.h > 0) {
+    cmd = mu_push_command(ctx, MU_COMMAND_IMAGE, sizeof(mu_ImageCommand));
+    cmd->image.rect = rect;
+    cmd->image.framebuffer = framebuffer;
+  }
+}
+
 
 void mu_draw_box(mu_Context *ctx, mu_Rect rect, mu_Color color) {
   mu_draw_rect(ctx, mu_rect(rect.x + 1, rect.y, rect.w - 2, 1), color);

--- a/src/microui.h
+++ b/src/microui.h
@@ -38,6 +38,7 @@ enum {
   MU_COMMAND_JUMP = 1,
   MU_COMMAND_CLIP,
   MU_COMMAND_RECT,
+  MU_COMMAND_IMAGE,
   MU_COMMAND_TEXT,
   MU_COMMAND_ICON,
   MU_COMMAND_MAX
@@ -120,6 +121,7 @@ typedef struct { int type, size; } mu_BaseCommand;
 typedef struct { mu_BaseCommand base; void *dst; } mu_JumpCommand;
 typedef struct { mu_BaseCommand base; mu_Rect rect; } mu_ClipCommand;
 typedef struct { mu_BaseCommand base; mu_Rect rect; mu_Color color; } mu_RectCommand;
+typedef struct { mu_BaseCommand base; mu_Rect rect; void* framebuffer; } mu_ImageCommand;
 typedef struct { mu_BaseCommand base; mu_Font font; mu_Vec2 pos; mu_Color color; char str[1]; } mu_TextCommand;
 typedef struct { mu_BaseCommand base; mu_Rect rect; int id; mu_Color color; } mu_IconCommand;
 
@@ -129,6 +131,7 @@ typedef union {
   mu_JumpCommand jump;
   mu_ClipCommand clip;
   mu_RectCommand rect;
+  mu_ImageCommand image;
   mu_TextCommand text;
   mu_IconCommand icon;
 } mu_Command;
@@ -248,6 +251,7 @@ mu_Command* mu_push_command(mu_Context *ctx, int type, int size);
 int mu_next_command(mu_Context *ctx, mu_Command **cmd);
 void mu_set_clip(mu_Context *ctx, mu_Rect rect);
 void mu_draw_rect(mu_Context *ctx, mu_Rect rect, mu_Color color);
+void mu_draw_image(mu_Context *ctx, mu_Rect rect, void* framebuffer);
 void mu_draw_box(mu_Context *ctx, mu_Rect rect, mu_Color color);
 void mu_draw_text(mu_Context *ctx, mu_Font font, const char *str, int len, mu_Vec2 pos, mu_Color color);
 void mu_draw_icon(mu_Context *ctx, int id, mu_Rect rect, mu_Color color);


### PR DESCRIPTION
A simple but effective interface to create a *draw image* command, allowing custom content to be rendered inside a rectangle.

While working on a personal project with this library, I felt the need to render custom content on the screen—such as a texture stored in a framebuffer—without losing the benefits of the layout system provided by the library. To achieve this, I introduced the `mu_draw_image` function, which essentially extends `mu_draw_rect` by accepting a pointer to a framebuffer for the image instead of a solid color.

Alongside this, the `mu_ImageCommand` was added to store the necessary data, together with the `MU_COMMAND_IMAGE` entry in the command-type enumeration.

This makes it possible to forward the request to the user-provided renderer, which can then draw the custom content on the screen.
<img width="1002" height="653" alt="Screenshot 2025-08-17 alle 18 26 30" src="https://github.com/user-attachments/assets/44cf7e49-ae81-495e-a2f3-d0091e0b1267" />
